### PR TITLE
[TP#37096] Create new context when .fail! is called

### DIFF
--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -121,9 +121,10 @@ module Interactor
     #
     # Raises Interactor::Failure initialized with the Interactor::Context.
     def fail!(context = {})
-      context.each { |key, value| self[key.to_sym] = value }
-      @failure = true
-      raise Failure, self
+      error_context = Context.new
+      context.each { |key, value| error_context[key.to_sym] = value }
+      error_context.failure = @failure = true
+      raise Failure, error_context
     end
 
     # Internal: Track that an Interactor has been called. The "called!" method

--- a/spec/interactor/context_spec.rb
+++ b/spec/interactor/context_spec.rb
@@ -58,6 +58,7 @@ module Interactor
 
     describe "#fail!" do
       let(:context) { Context.build(foo: "bar") }
+      let(:error_context) { Context.build }
 
       it "sets success to false" do
         expect {
@@ -113,41 +114,25 @@ module Interactor
         }
       end
 
-      it "updates the context" do
-        expect {
-          begin
-            context.fail!(foo: "baz")
-          rescue
-            nil
-          end
-        }.to change {
-          context.foo
-        }.from("bar").to("baz")
-      end
-
-      it "updates the context with a string key" do
-        expect {
-          begin
-            context.fail!("foo" => "baz")
-          rescue
-            nil
-          end
-        }.to change {
-          context.foo
-        }.from("bar").to("baz")
-      end
-
       it "raises failure" do
         expect {
           context.fail!
         }.to raise_error(Failure)
       end
 
-      it "makes the context available from the failure" do
+      it "error context does not contain context attributes" do
         begin
           context.fail!
         rescue Failure => error
-          expect(error.context).to eq(context)
+          expect(error.context.foo).to eq(nil)
+        end
+      end
+
+      it "context does not equal error context" do
+        begin
+          context.fail!
+        rescue Failure => error
+          expect(context).to_not eq(error.context)
         end
       end
     end


### PR DESCRIPTION
[TP#37096](https://callrail.tpondemand.com/restui/board.aspx?#page=bug/37096)
[TP#37065](https://callrail.tpondemand.com/RestUI/Board.aspx#page=board/5074093876529013135&appConfig=eyJhY2lkIjoiRDFDODMxODFGNzg0QjQ5RDlFN0NGQzE5MkIzQTU1NUYifQ==&boardPopup=bug/37065/silent)

## Overview

This is a blanket fix for the bug that exposes sensitive information to logging systems (i.e. Honey Badger). This creates a new context when the .fail! method is called removing the context that may contain sensitive information. This still passes any failure message you pass via the .fail! method.